### PR TITLE
Add builtin user account creds

### DIFF
--- a/src/UserCredentials.cs
+++ b/src/UserCredentials.cs
@@ -17,6 +17,21 @@ namespace SimpleImpersonation
         private readonly SecureString _securePassword;
 
         /// <summary>
+        /// Credentials for "NT AUTHORITY\NETWORK SERVICE"
+        /// </summary>
+        public static UserCredentials NetworkService => new UserCredentials("NETWORK SERVICE");
+
+        /// <summary>
+        /// Credentials for "NT AUTHORITY\SYSTEM"
+        /// </summary>
+        public static UserCredentials LocalSystem => new UserCredentials("SYSTEM");
+
+        /// <summary>
+        /// Credentials for "NT AUTHORITY\LOCAL SERVICE"
+        /// </summary>
+        public static UserCredentials LocalService => new UserCredentials("LOCAL SERVICE");
+
+        /// <summary>
         /// Creates a <see cref="UserCredentials"/> class based on a username and plaintext password.
         /// The username can contain a domain name if specified in <c>domain\user</c> or <c>user@domain</c> form.
         /// If no domain is provided, a local computer user account is assumed.
@@ -84,6 +99,13 @@ namespace SimpleImpersonation
             _domain = domain;
             _username = username;
             _securePassword = password;
+        }
+
+        private UserCredentials(string builtInAccount)
+        {
+            _domain = "NT AUTHORITY";
+            _username = builtInAccount;
+            _password = string.Empty;
         }
 
         internal SafeAccessTokenHandle Impersonate(LogonType logonType)

--- a/test/SimpleImpersonation.UnitTests/UserCredentialsTests.cs
+++ b/test/SimpleImpersonation.UnitTests/UserCredentialsTests.cs
@@ -248,6 +248,23 @@ namespace SimpleImpersonation.UnitTests
             });
         }
 
+        [Fact]
+        public void UserCredentials_NetworkService_Valid()
+        {
+            Assert.Equal("NETWORK SERVICE@NT AUTHORITY", UserCredentials.NetworkService.ToString(), ignoreCase: true);
+        }
+
+        [Fact]
+        public void UserCredentials_LocalSystem_Valid()
+        {
+            Assert.Equal("SYSTEM@NT AUTHORITY", UserCredentials.LocalSystem.ToString(), ignoreCase: true);
+        }
+
+        [Fact]
+        public void UserCredentials_LocalService_Valid()
+        {
+            Assert.Equal("LOCAL SERVICE@NT AUTHORITY", UserCredentials.LocalService.ToString(), ignoreCase: true);
+        }
 
         private static SecureString CreateSecureStringPasswordForTesting()
         {


### PR DESCRIPTION
I had a need to impersonate some builtin accounts like Network Service. Unfortunately all the constructors in `UserCredentials` prevented me from passing an empty password. So I created a private constructor and just used static properties to create builtin accounts. Seems to work well!

EDIT: Oh.... I _just_ now saw [the other pull request](https://github.com/mj1856/SimpleImpersonation/pull/42)... No worries if you want to close this one.