### PR TITLE
Add Licence metadata to Nuget Package

### DIFF
--- a/src/SimpleImpersonation.csproj
+++ b/src/SimpleImpersonation.csproj
@@ -6,8 +6,9 @@
     <TargetFrameworks>netstandard20;net46;net45;net40;net35;net20</TargetFrameworks>
     <PackageId>SimpleImpersonation</PackageId>
     <PackageTags>impersonation user password domain logonuser win32</PackageTags>
-    <PackageProjectUrl>https://github.com/mj1856/SimpleImpersonation</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.github.com/mj1856/SimpleImpersonation/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/mattjohnsonpint/SimpleImpersonation</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/mattjohnsonpint/SimpleImpersonation/master/LICENSE.txt</PackageLicenseUrl>
+	<PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
     <Version>3.0.0</Version>


### PR DESCRIPTION
Some firms use automatic systems to check OSS package licences for regulatory audits etc.

licenceUrl is depreciated as of nuget 4.9.0 replaced by licence. https://docs.microsoft.com/en-us/nuget/reference/nuspec#licenseurl

The licence metadata makes it easier for automated systems to audit OSS packages.

Also updated URLs to reflect username change