### PR TITLE
Added Logon Provider support

### DIFF
--- a/src/Impersonation.cs
+++ b/src/Impersonation.cs
@@ -35,10 +35,40 @@ namespace SimpleImpersonation
         /// </summary>
         /// <param name="credentials">The credentials of the user account to impersonate.</param>
         /// <param name="logonType">The logon type used when impersonating the user account.</param>
+        /// <param name="logonProvider">The logon provider used when impersonating the user account.</param>
+        /// <param name="action">The action to perform.</param>
+        public static void RunAsUser(UserCredentials credentials, LogonType logonType, LogonProvider logonProvider, Action action)
+        {
+            using (var tokenHandle = credentials.Impersonate(logonType, logonProvider))
+            {
+                RunImpersonated(tokenHandle, _ => action());
+            }
+        }
+
+        /// <summary>
+        /// Impersonates a specific user account to perform the specified action.
+        /// </summary>
+        /// <param name="credentials">The credentials of the user account to impersonate.</param>
+        /// <param name="logonType">The logon type used when impersonating the user account.</param>
         /// <param name="action">The action to perform, which accepts a <see cref="SafeAccessTokenHandle"/> to the user account as its only parameter.</param>
         public static void RunAsUser(UserCredentials credentials, LogonType logonType, Action<SafeAccessTokenHandle> action)
         {
             using (var tokenHandle = credentials.Impersonate(logonType))
+            {
+                RunImpersonated(tokenHandle, action);
+            }
+        }
+
+        /// <summary>
+        /// Impersonates a specific user account to perform the specified action.
+        /// </summary>
+        /// <param name="credentials">The credentials of the user account to impersonate.</param>
+        /// <param name="logonType">The logon type used when impersonating the user account.</param>
+        /// <param name="logonProvider">The logon provider used when impersonating the user account.</param>
+        /// <param name="action">The action to perform, which accepts a <see cref="SafeAccessTokenHandle"/> to the user account as its only parameter.</param>
+        public static void RunAsUser(UserCredentials credentials, LogonType logonType, LogonProvider logonProvider, Action<SafeAccessTokenHandle> action)
+        {
+            using (var tokenHandle = credentials.Impersonate(logonType, logonProvider))
             {
                 RunImpersonated(tokenHandle, action);
             }
@@ -66,11 +96,45 @@ namespace SimpleImpersonation
         /// <typeparam name="T">The return type of the function.</typeparam>
         /// <param name="credentials">The credentials of the user account to impersonate.</param>
         /// <param name="logonType">The logon type used when impersonating the user account.</param>
+        /// <param name="logonProvider">The logon provider used when impersonating the user account.</param>
+        /// <param name="function">The function to execute, which accepts a <see cref="SafeAccessTokenHandle"/> to the user account as its only parameter.</param>
+        /// <returns>The result of executing the function.</returns>
+        public static T RunAsUser<T>(UserCredentials credentials, LogonType logonType, LogonProvider logonProvider, Func<T> function)
+        {
+            using (var tokenHandle = credentials.Impersonate(logonType, logonProvider))
+            {
+                return RunImpersonated(tokenHandle, _ => function());
+            }
+        }
+
+        /// <summary>
+        /// Impersonates a specific user account to execute the specified function.
+        /// </summary>
+        /// <typeparam name="T">The return type of the function.</typeparam>
+        /// <param name="credentials">The credentials of the user account to impersonate.</param>
+        /// <param name="logonType">The logon type used when impersonating the user account.</param>
         /// <param name="function">The function to execute.</param>
         /// <returns>The result of executing the function.</returns>
         public static T RunAsUser<T>(UserCredentials credentials, LogonType logonType, Func<SafeAccessTokenHandle, T> function)
         {
             using (var tokenHandle = credentials.Impersonate(logonType))
+            {
+                return RunImpersonated(tokenHandle, function);
+            }
+        }
+
+        /// <summary>
+        /// Impersonates a specific user account to execute the specified function.
+        /// </summary>
+        /// <typeparam name="T">The return type of the function.</typeparam>
+        /// <param name="credentials">The credentials of the user account to impersonate.</param>
+        /// <param name="logonType">The logon type used when impersonating the user account.</param>
+        /// <param name="logonProvider">The logon provider used when impersonating the user account.</param>
+        /// <param name="function">The function to execute.</param>
+        /// <returns>The result of executing the function.</returns>
+        public static T RunAsUser<T>(UserCredentials credentials, LogonType logonType, LogonProvider logonProvider, Func<SafeAccessTokenHandle, T> function)
+        {
+            using (var tokenHandle = credentials.Impersonate(logonType, logonProvider))
             {
                 return RunImpersonated(tokenHandle, function);
             }

--- a/src/LogonProvider.cs
+++ b/src/LogonProvider.cs
@@ -1,0 +1,20 @@
+﻿namespace SimpleImpersonation
+{
+    /// <summary>
+    /// Specifies the type of login provider used.
+    /// http://msdn.microsoft.com/en-us/library/windows/desktop/aa378184.aspx
+    /// </summary>
+    public enum LogonProvider
+    {
+        /// <summary>
+        /// Use the standard logon provider for the system.
+        /// The default security provider is negotiate, unless you pass NULL for the domain name and the user name
+        /// is not in UPN format. In this case, the default provider is NTLM.
+        /// NOTE: Windows 2000/NT:   The default security provider is NTLM.
+        /// </summary>
+        Default = 0,
+        WINNT35 = 1,
+        WINNT40 = 2,
+        WINNT50 = 3,
+    }
+}

--- a/src/UserCredentials.cs
+++ b/src/UserCredentials.cs
@@ -110,9 +110,14 @@ namespace SimpleImpersonation
 
         internal SafeAccessTokenHandle Impersonate(LogonType logonType)
         {
+            return Impersonate(logonType, LogonProvider.Default);
+        }
+        
+        internal SafeAccessTokenHandle Impersonate(LogonType logonType, LogonProvider logonProvider)
+        {
             if (_securePassword == null)
             {
-                if (!NativeMethods.LogonUser(_username, _domain, _password, (int)logonType, 0, out var tokenHandle))
+                if (!NativeMethods.LogonUser(_username, _domain, _password, (int)logonType, (int)logonProvider, out var tokenHandle))
                     HandleError(tokenHandle);
 
                 return new SafeAccessTokenHandle(tokenHandle);
@@ -122,7 +127,7 @@ namespace SimpleImpersonation
 
             try
             {
-                if (!NativeMethods.LogonUser(_username, _domain, passPtr, (int)logonType, 0, out var tokenHandle))
+                if (!NativeMethods.LogonUser(_username, _domain, passPtr, (int)logonType, (int)logonProvider, out var tokenHandle))
                     HandleError(tokenHandle);
 
                 return new SafeAccessTokenHandle(tokenHandle);


### PR DESCRIPTION
Logon Provider is neccessary especially when providing `LogonType.NewCredentials` as logon type. In this situation, `LogonProvider.WINNT50` is required as provider.